### PR TITLE
add PHP gd library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,15 @@
 
 FROM php:7-apache
 
+RUN apt-get update \
+  && apt-get install -y \
+    zlib1g-dev \
+    libpng-dev \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-install mysqli
+RUN docker-php-ext-install gd
 
 COPY tng12.1/ /var/www/html/
 


### PR DESCRIPTION
I just installed TNG for my father (Version 13.0.1) and found that the TNG system check (admin_diagnostics.php) showed a missing GD graphics library PHP extension.
So I changed the Dockerfile to build the image with the GD extension (it needs libpng and zlib).